### PR TITLE
Adjust minOccurs in XSD

### DIFF
--- a/src/main/resources/xsd/istar-rl-schema_v4.xsd
+++ b/src/main/resources/xsd/istar-rl-schema_v4.xsd
@@ -112,7 +112,7 @@
             <xsd:documentation><![CDATA[Container for exports.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="export" type="ExportType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="export" type="ExportType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single export.]]></xsd:documentation>
                 </xsd:annotation>
@@ -144,7 +144,7 @@
             <xsd:documentation><![CDATA[Container for cross-runs.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="crossRun" type="CrossRunType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="crossRun" type="CrossRunType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single cross-run.]]></xsd:documentation>
                 </xsd:annotation>
@@ -170,7 +170,7 @@
             <xsd:documentation><![CDATA[Container for variables.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="variable" type="VariableType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="variable" type="VariableType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single variable.]]></xsd:documentation>
                 </xsd:annotation>
@@ -199,7 +199,7 @@
             <xsd:documentation><![CDATA[Container for initializations.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="initialization" type="InitializationType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="initialization" type="InitializationType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single initialization.]]></xsd:documentation>
                 </xsd:annotation>
@@ -237,7 +237,7 @@
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="predicate" type="PredicateType"
-                         minOccurs="1" maxOccurs="unbounded">
+                         minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[
                         Defines a single predicate.
@@ -271,7 +271,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="condBox" type="CondBoxType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="condBox" type="CondBoxType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -486,7 +486,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="quality" type="QualityType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="quality" type="QualityType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -511,7 +511,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="goal" type="GoalType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="goal" type="GoalType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -600,7 +600,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="task" type="TaskType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="task" type="TaskType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -653,7 +653,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="effect" type="EffectType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="effect" type="EffectType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/src/test/resources/xsd/istar-rl-schema_v4.xsd
+++ b/src/test/resources/xsd/istar-rl-schema_v4.xsd
@@ -112,7 +112,7 @@
             <xsd:documentation><![CDATA[Container for exports.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="export" type="ExportType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="export" type="ExportType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single export.]]></xsd:documentation>
                 </xsd:annotation>
@@ -144,7 +144,7 @@
             <xsd:documentation><![CDATA[Container for cross-runs.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="crossRun" type="CrossRunType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="crossRun" type="CrossRunType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single cross-run.]]></xsd:documentation>
                 </xsd:annotation>
@@ -170,7 +170,7 @@
             <xsd:documentation><![CDATA[Container for variables.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="variable" type="VariableType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="variable" type="VariableType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single variable.]]></xsd:documentation>
                 </xsd:annotation>
@@ -199,7 +199,7 @@
             <xsd:documentation><![CDATA[Container for initializations.]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="initialization" type="InitializationType" minOccurs="1" maxOccurs="unbounded">
+            <xsd:element name="initialization" type="InitializationType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[Defines a single initialization.]]></xsd:documentation>
                 </xsd:annotation>
@@ -237,7 +237,7 @@
         </xsd:annotation>
         <xsd:sequence>
             <xsd:element name="predicate" type="PredicateType"
-                         minOccurs="1" maxOccurs="unbounded">
+                         minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation><![CDATA[
                         Defines a single predicate.
@@ -271,7 +271,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="condBox" type="CondBoxType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="condBox" type="CondBoxType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -486,7 +486,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="quality" type="QualityType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="quality" type="QualityType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -511,7 +511,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="goal" type="GoalType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="goal" type="GoalType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -600,7 +600,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="task" type="TaskType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="task" type="TaskType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 
@@ -653,7 +653,7 @@
             ]]></xsd:documentation>
         </xsd:annotation>
         <xsd:sequence>
-            <xsd:element name="effect" type="EffectType" minOccurs="1" maxOccurs="unbounded"/>
+            <xsd:element name="effect" type="EffectType" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
     </xsd:complexType>
 


### PR DESCRIPTION
Allow empty  exportedSet, crossRuns and initializations.